### PR TITLE
fix: Pass a correct file path to handleMistFileUpdate

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -62,7 +62,7 @@ if (fs.statSync(fileOrDir).isFile()) {
   const genFiles = await globby(genGlob, { cwd })
 
   function handleMistFileUpdate(filename: string) {
-    safeCreateFile(filename)
+    safeCreateFile(path.join(cwd, filename))
   }
 
   function handleMistFileDelete(filename: string) {


### PR DESCRIPTION
The build command didn't work for me, and this change seems necessary. Is there anything I'm missing?