### PR TITLE
fix: fix rendered code when user defined props are not passed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,9 +107,11 @@ type Props = {
   ${renderProps(parsedInput)}
 } & JSX.IntrinsicElements['${parsedInput.tag}']
 
-export function ${name}({ children, ${Object.keys(parsedInput.data).join(
-    ', ',
-  )}, ...props }: Props) {
+export function ${name}({ ${[
+    'children',
+    ...Object.keys(parsedInput.data),
+    '...props',
+  ].join(', ')} }: Props) {
   return (
     <${parsedInput.tag} {...props} className="${parsedInput.className}" ${Object.keys(
       parsedInput.data,


### PR DESCRIPTION
# Problem Description
If the user does not pass any custom props, then the generated code will have an extra comma (,) 
Example: 
```
Button.mist.css
---
@scope (.button) {
  button:scope {
    /* Default style */
    font-size: 1rem;
    border-radius: 0.25rem;
  }
}
```

```
Button.mist.tsx
---
export function Button ({ className, , ...props }: Props) {
```

# Video Explanation
[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/9jrNwmj73F4/0.jpg)](https://youtu.be/9jrNwmj73F4?si=pZDtNdG6OTqNQUba&t=212)
Timestamp: 3:32 - 3:52
Credits: [Josh tried coding](https://www.youtube.com/@joshtriedcoding)