### PR TITLE
fix: fix rendered code tag having trailing space

### DIFF
--- a/fixtures/Foo.mist.tsx
+++ b/fixtures/Foo.mist.tsx
@@ -36,7 +36,7 @@ type BazProps = {
 
 export function Baz({ children, ...props }: BazProps) {
   return (
-    <p {...props} className="Baz" >
+    <p {...props} className="Baz">
       {children}
     </p>
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,11 +140,12 @@ export function ${name}({ ${[
     '...props',
   ].join(', ')} }: ${name}Props) {
   return (
-    <${component.tag} {...props} className="${name}" ${Object.keys(
-      component.data,
-    )
-      .map((key) => `data-${key}={${key}}`)
-      .join(' ')}>
+    <${[
+      component.tag,
+      '{...props}',
+      `className="${name}"`,
+      ...Object.keys(component.data).map((key) => `data-${key}={${key}}`),
+    ].join(' ')}>
       {children}
     </${component.tag}>
   )


### PR DESCRIPTION
# Description
In the below test case, there is a trailing space in the tag with no user-defined props.
```typescript
export function Baz({ children, ...props }: BazProps) {
  return (
    <p {...props} className="Baz" >   <<<< Notice this space
      {children}
    </p>
  )
}
```

The same is true when we create components without user-defined props, the output is similar.

# Checklist
- [x] Remove trailing space.
- [x] Updated test case definition.