### PR TITLE
docs: fix invalid documentation on tailwind the example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,7 @@ Let's create a classic `Button` component accepting two props:
 @scope (.button) {
   button:scope {
     /* Default style */
-    @apply text-md rounded-sm;
+    @apply text-base rounded-sm;
 
     &[data-size='lg'] {
       @apply text-lg;
@@ -73,7 +73,7 @@ Let's create a classic `Button` component accepting two props:
     }
 
     &[data-danger] {
-      @apply bg-red-700 @text-white;
+      @apply bg-red-700 text-white;
     }
   }
 }


### PR DESCRIPTION
# Description
The tailwind example in the documentation contains erroneous syntaxes. This PR fixes those mistakes.

# Checklist
- [x] Updated text-md to text-base as text-md is now removed.
- [x] Removed @ for the `text-white` class, leading to the class not being applied. 