### PR TITLE
enh: replace type of ext by specific string

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -7,6 +7,7 @@ import chokidar from 'chokidar'
 import { globby } from 'globby'
 
 import { createFile } from './writer.js'
+import { Extension } from './types/types.js'
 
 function usage() {
   console.log(`Usage: mistcss <directory> [options]
@@ -51,7 +52,7 @@ if (['react', 'hono', 'astro'].includes(values.target!) === false) {
   process.exit(1)
 }
 
-let ext = ''
+let ext: Extension
 switch (values.target) {
   case 'react':
     ext = '.tsx'
@@ -65,6 +66,10 @@ switch (values.target) {
     ext = '.astro'
     console.log('Rendering Astro components')
     break
+  default:
+    console.error('Invalid render option')
+    usage()
+    process.exit(1)
 }
 
 // Change directory

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,0 +1,1 @@
+export type Extension = '.tsx' | '.astro'

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -4,9 +4,10 @@ import path from 'node:path'
 import { parse } from './parser.js'
 import { render as reactRender } from './renderers/react.js'
 import { render as astroRender } from './renderers/astro.js'
+import { Extension } from './types/types.js'
 
 // Create a file from a mist file
-export function createFile(mist: string, target: string, ext: string) {
+export function createFile(mist: string, target: string, ext: Extension) {
   try {
     const data = parse(fs.readFileSync(mist, 'utf8'))
     const name = path.basename(mist, '.mist.css')
@@ -14,14 +15,15 @@ export function createFile(mist: string, target: string, ext: string) {
         let result = ''
         switch (target) {
           case 'react':
+            // .tsx
             result = reactRender(name, data[0])
             break
           case 'hono':
-            ext = '.tsx'
+            // .tsx
             result = reactRender(name, data[0], true)
             break
           case 'astro':
-            ext = '.astro'
+            // .astro
             result = astroRender(name, data[0])
             break
         }


### PR DESCRIPTION
It looks better to have specific string instead of general string for the variable, `ext`. As well, I removed the duplicate `ext` logic inside the function, `createFile`, and replaced it by the parameter.