### PR TITLE
docs: update start.mdx to fix broken page links

### DIFF
--- a/docs/src/content/docs/start.mdx
+++ b/docs/src/content/docs/start.mdx
@@ -52,7 +52,7 @@ The above code is 100% valid CSS and natively supported by browsers.
 
 :::note
 
-MistCSS components support enum, boolean and string props. See [Writing Components](components).
+MistCSS components support enum, boolean and string props. See [Writing Components](component).
 
 :::
 
@@ -75,6 +75,6 @@ export const App = () => <CustomButton variant="primary">Save</CustomButton>
 
 :::note
 
-MistCSS supports creating React, Astro and Hono components. See [frameworks](frameworks).
+MistCSS supports creating React, Astro and Hono components. See [frameworks](./integration/frameworks).
 
 :::


### PR DESCRIPTION
There were a couple of links from the start page that failed to link correctly to their targets. This change updates those link targets to correctly redirect to the expected page.