### PR TITLE
Allow components not preceded by a comment

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -22,8 +22,8 @@ export interface Data {
 
 function getComment(element: Element): string {
   // @ts-ignore
-  const prev = element.siblings[element.siblings.indexOf(element) - 1] as Element
-  if (prev.type === COMMENT) {
+  const prev = element.siblings[element.siblings.indexOf(element) - 1] as Element | undefined
+  if (prev?.type === COMMENT) {
     return (prev.children as string).trim()
   }
   return ''


### PR DESCRIPTION
At present, mistcss fails if a component is not preceded by any element. This means even a trivial example without a comment does not work. Unless this is intentional, I want this to be more permissive.