### PR TITLE
fix: correct file cleanup logic in mist file processing

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -151,9 +151,9 @@ if (values.watch) {
 )
 
 // Clean out files without a matching mist file
-;(await globby(`**/*.mist.${ext}`)).forEach((file) => {
-  const mist = file.replace(new RegExp(`\.${ext}$`), '.css')
+;(await globby(`**/*.mist${ext}`)).forEach((file) => {
+  const mist = file.replace(new RegExp(`${ext}$`), '.css')
   if (!fs.existsSync(mist)) {
-    fsPromises.unlink(mist).catch(() => false)
+    fsPromises.unlink(file).catch(() => false)
   }
 })


### PR DESCRIPTION
- Updated the glob pattern for matching mist files by removing the dot from the extension, as `ext` already includes it.
- Ensured that the generated file is deleted when no corresponding mist css file exists.