### PR TITLE
fix: make custom properties optional in created types (#69)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ function render(parsed: Parsed): string {
 
         if (Array.from(properties).length > 0) {
           const propertyEntries = Array.from(properties)
-            .map((prop) => `'${prop}': string`)
+            .map((prop) => `'${prop}'?: string`)
             .join(', ')
           interfaceDefinition += `  style?: { ${propertyEntries} } & React.CSSProperties\n`
         }

--- a/test/button.mist.css
+++ b/test/button.mist.css
@@ -1,4 +1,5 @@
 button {
+  --highlightColor: rebeccapurple;
   padding: 0.5rem 1rem;
   border-radius: 0.25rem;
   font-weight: bold;

--- a/test/mist.d.ts
+++ b/test/mist.d.ts
@@ -1,5 +1,6 @@
 interface Mist_button extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   'data-variant'?: 'primary' | 'secondary'
+  style?: { '--highlightColor'?: string } & React.CSSProperties
 }
 
 interface Mist_div extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {


### PR DESCRIPTION
This branch makes custom properties optional in the created types, as discussed in #69.

> Mist can only discover custom properties that have been declared with a default value in a style. Style consumers may not wish to override this default.